### PR TITLE
Fixed issue where commands interfered with each other by modifying the same file

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ async function run() {
 
         const command = `agvtool new-marketing-version ${version}`
         console.log(command)
-        execCommand(command).catch(error => {
+        await execCommand(command).catch(error => {
             core.setFailed(error.message)
         })
     }


### PR DESCRIPTION
When using both options `version` and `build-number` at the same time these commands were executed simultaneously and it looks like they interfere with each other. An `await` is added to wait before the 'version' command is finished before proceeding to execute the 'build-number' command.

To provide some additional context on how I came to this conclusion, I have some snippets of our GitHub Actions log.  One snippet is of a successful build and the other is of a failed build. I've compared the output of the commands `agvtool new-marketing-version 1.1.0` and `agvtool new-version -all 58` in the Actions log with the output when I executed these commands locally and have marked the different output lines with `A` and `B`. That way you can see that the output and timing of these 2 commands is slightly different on the failed build and possibly caused a corrupt `Info.plist` file which triggered a failure of the last command `agvtool what-version -terse`.

Successful build:
```
A  [command]/usr/bin/agvtool new-marketing-version 1.1.0
B  [command]/usr/bin/agvtool new-version -all 58
B  Setting version of project App to: 
B      58.

A  Setting CFBundleShortVersionString of project App to: 
A      1.1.0.

B  Also setting CFBundleVersion key (assuming it exists)

A  Updating CFBundleShortVersionString in Info.plist(s)...

rm: App.xcodeproj/project.pbxproj.new1: No such file or directory
B  Updating CFBundleVersion in Info.plist(s)...

A  Updated CFBundleShortVersionString in "App.xcodeproj/../App/Info.plist" to 1.1.0
B  Updated CFBundleVersion in "App.xcodeproj/../App/Info.plist" to 58

C  [command]/usr/bin/agvtool what-version -terse
C  <Buffer 35 38 0a>
C  58
```

Failed build:
```
A  [command]/usr/bin/agvtool new-marketing-version 1.1.0
B  [command]/usr/bin/agvtool new-version -all 59
B  Setting version of project App to: 
B      59.

A  Setting CFBundleShortVersionString of project App to: 
A      1.1.0.

A  Updating CFBundleShortVersionString in Info.plist(s)...

sed: App.xcodeproj/project.pbxproj.new1: No such file or directory
B  Also setting CFBundleVersion key (assuming it exists)

rm: App.xcodeproj/project.pbxproj.new1: No such file or directory

A  Updated CFBundleShortVersionString in "App.xcodeproj/../App/Info.plist" to 1.1.0

C  [command]/usr/bin/agvtool what-version -terse
(node:2870) UnhandledPromiseRejectionWarning: Error: The process '/usr/bin/agvtool' failed with exit code 6
    at ExecState._setResult (/Users/runner/work/_actions/yanamura/ios-bump-version/v1/dist/index.js:920:25)
    at ExecState.CheckComplete (/Users/runner/work/_actions/yanamura/ios-bump-version/v1/dist/index.js:903:18)
    at ChildProcess.<anonymous> (/Users/runner/work/_actions/yanamura/ios-bump-version/v1/dist/index.js:797:27)
    at ChildProcess.emit (events.js:210:5)
    at maybeClose (internal/child_process.js:1021:16)
    at Socket.<anonymous> (internal/child_process.js:430:11)
    at Socket.emit (events.js:210:5)
    at Pipe.<anonymous> (net.js:659:12)
(node:2870) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2870) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

I also want to mention that in the last couple of weeks we had multiple random failures of our build, which we couldn't really explain. We tried several things and most of the time it suddenly worked again. At the time it felt like some kind of timing or caching issue, but we couldn't figure out what caused these failures. Now that I stumbled upon these commands, that were executed simultaneously and also writing to the same file, I think we may found the cause of the random build failures.

Hopefully this al make sense 😇 Please let me know if I've missed something or when additional changes are needed ✌️ 