### PR TITLE
node12 to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ outputs:
   build-number:
     description: "new build number"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 branding:
   icon: "arrow-up"


### PR DESCRIPTION
fix this warning

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16
```

#33 